### PR TITLE
Fixed build for macOS & Catalyst platforms.

### DIFF
--- a/build-openssl.sh
+++ b/build-openssl.sh
@@ -64,7 +64,7 @@ SCRIPTDIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 #—————————————————————————————————————————————————————————————————————————————————————————
 
 # Default version in case no version is specified.
-DEFAULTVERSION="1.1.1d"
+DEFAULTVERSION="1.1.1g"
 
 # Available set of targets to build. This is distinct from the default set, below, in that this
 # reflects everything that's available to build, whereas you may want to choose a different set

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -10,7 +10,7 @@ my %targets = ();
     
     "all-base" => {
         template         => 1,
-        cflags           => '-isysroot $(CROSS_TOP)/SDKs/$(CROSS_SDK) -fno-common'
+        cflags           => '-isysroot $(CROSS_SYSROOT) -fno-common'
     },
     
     "iphoneos-base" => {

--- a/scripts/lib-build-openssl.sh
+++ b/scripts/lib-build-openssl.sh
@@ -225,9 +225,11 @@ target_build_loop()
       ARCH=$(echo "${TARGET}" | sed -E 's|^.*\-([^\-]+)$|\1|g')
 
       # Cross compile references, see Configurations/10-main.conf
+      local SDK_NAME=`echo "${PLATFORM}" | tr '[:upper:]' '[:lower:]'`
       export CROSS_COMPILE="${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/"
       export CROSS_TOP="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
       export CROSS_SDK="${PLATFORM}${SDKVERSION}.sdk"
+      export CROSS_SYSROOT=`xcrun -sdk $SDK_NAME --show-sdk-path`
 
       # Prepare TARGETDIR and SOURCEDIR
       SUBPLATFORM="${PLATFORM}"

--- a/scripts/lib-frameworks.sh
+++ b/scripts/lib-frameworks.sh
@@ -108,10 +108,10 @@ function build_libraries() {
         fi
 
         echo "Assembling .dylib and .a for $PLATFORM $SDKVERSION ($ARCH)"
-
+        local SDK_NAME=`echo "${_platform}" | tr '[:upper:]' '[:lower:]'`
         CROSS_TOP="${DEVELOPER}/Platforms/${_platform}.platform/Developer"
         CROSS_SDK="${_platform}${SDKVERSION}.sdk"
-        SDK="${CROSS_TOP}/SDKs/${CROSS_SDK}"
+        SDK=`xcrun -sdk $SDK_NAME --show-sdk-path`
 
         if [[ $PLATFORM == AppleTVSimulator* ]]; then
             MIN_SDK="-tvos_simulator_version_min $TVOS_MIN_SDK_VERSION"


### PR DESCRIPTION
This PR fixes path calculation for platform SDK. Now the SDK path is calculated by `xcrun` tool, instead of manual concatenation of various strings, like platform & SDK version.

The reason for this change is that the current macOSX SDK is in version `10.15.4` but the real path contains only `Major.Minor` version (e.g. `10.15`).