### PR TITLE
Add support for building for arm64, once OpenSSL does.

### DIFF
--- a/build-openssl.sh
+++ b/build-openssl.sh
@@ -69,7 +69,7 @@ DEFAULTVERSION="1.1.1d"
 # Available set of targets to build. This is distinct from the default set, below, in that this
 # reflects everything that's available to build, whereas you may want to choose a different set
 # of defaults.
-TARGETS_AVAILABLE="ios-sim-cross-x86_64 ios-cross-armv7 ios64-cross-arm64 mac-catalyst-x86_64 tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64 watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-i386"
+TARGETS_AVAILABLE="ios-sim-cross-x86_64 ios-cross-armv7 ios64-cross-arm64 mac-catalyst-x86_64 tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64 macos64-arm64 watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-i386"
 
 # Default set of architectures (OpenSSL <= 1.0.2) or targets (OpenSSL >= 1.1.1) to build
 TARGETS_DEFAULT="$TARGETS_AVAILABLE"
@@ -447,6 +447,9 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
     case "${OPENSSLCONF_CURRENT}" in
       *_macos_x86_64.h)
         DEFINE_CONDITION="TARGET_OS_OSX && TARGET_CPU_X86_64"
+      ;;
+      *_macos_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_OSX && TARGET_CPU_ARM64"
       ;;
       *_macos_i386.h)
         DEFINE_CONDITION="TARGET_OS_OSX && TARGET_CPU_X86"

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -152,4 +152,10 @@ my %targets = ();
         sys_id           => "macOS",
     },
 
+    "macos64-arm64" => {
+        inherit_from     => ["darwin64-arm64-cc", "macos-base"],
+        sys_id           => "macOS",
+        cflags           => add("-mmacosx-version-min=11.0")
+    }
+
 );

--- a/scripts/lib-frameworks.sh
+++ b/scripts/lib-frameworks.sh
@@ -119,6 +119,9 @@ function build_libraries() {
             MIN_SDK="-tvos_version_min $TVOS_MIN_SDK_VERSION"
         elif [[ $PLATFORM == MacOSX* ]]; then
             MIN_SDK="-macosx_version_min $MACOS_MIN_SDK_VERSION"
+            if [[ $ARCH == arm64 ]]; then
+                MIN_SDK="-macosx_version_min 11.0"
+            fi
         elif [[ $PLATFORM == Catalyst* ]]; then
             MIN_SDK="-platform_version mac-catalyst 13.0 $CATALYST_MIN_SDK_VERSION"
         elif [[ $PLATFORM == iPhoneSimulator* ]]; then


### PR DESCRIPTION
I've tested this out with an OpenSSL build that has support for darwin64-arm64, and was able to build a universal OpenSSL build for both x86_64 and arm64. (See https://github.com/openssl/openssl/pull/12369)

Without an updated version of OpenSSL, this fails because the `macos-arm64` target ends up re-compiling for x86_64 instead, and then `lipo` fails to merge the two together because they both have the same architecture. It seems like it would make sense to remove `macos-arm64` from the default targets if the underlying OpenSSL doesn't support it, but I'm not sure if there's a feasible way to do that.